### PR TITLE
[PR] Jinyeong #4 detail page create

### DIFF
--- a/src/components/DetailPageComponents/AuctionInfoModule.tsx
+++ b/src/components/DetailPageComponents/AuctionInfoModule.tsx
@@ -1,0 +1,94 @@
+import React from 'react'
+import styled from 'styled-components';
+
+const InfoContainer = styled.div`
+  border: 1px solid #eee;
+  border-radius: 8px;
+  padding: 16px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+`;
+
+const Title = styled.h1`
+  font-size: 20px;
+  font-weight: bold;
+  margin-bottom: 16px;
+  border-bottom: 1px solid #eee;
+  padding-bottom: 8px;
+`;
+
+const Row = styled.div`
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 8px;
+`;
+
+const Label = styled.div`
+  font-size: 14px;
+  color: #666;
+`;
+
+const Value = styled.div`
+  font-size: 14px;
+  font-weight: bold;
+`;
+
+const HighlightedValue = styled(Value)`
+  color: red;
+`;
+
+const BuyNowButton = styled.button`
+  background-color: orange;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  padding: 8px 16px;
+  cursor: pointer;
+  font-size: 16px;
+  align-self: center;
+  &:hover {
+    background-color: darkorange;
+  }
+`;
+
+const Divider = styled.hr`
+  border: 1px solid #eee;
+  width: 95%;
+  border-color: black;
+  border-style: solid;
+  border-width: 1px 0 0 0;
+`
+
+export default function AuctionInfoModule() {
+  return (
+    <InfoContainer>
+      <Title>상품 제목</Title>
+      <Row>
+        <Label>입찰 건수</Label>
+        <Value>3</Value>
+        <Label>남은 시간</Label>
+        <HighlightedValue>23:07:18</HighlightedValue>
+      </Row>
+      <Row>
+        <Label>시작 시간</Label>
+        <Value>2024.07.01 20:31:05</Value>
+        <Label>종료 시간</Label>
+        <Value>2024.07.03 20:31:05</Value>
+      </Row>
+      <Divider />
+      <Row>
+        <Label>시작 가격</Label>
+        <Value>15,000 원</Value>
+        <Label>현재 입찰 가격</Label>
+        <Value>30,000 원</Value>
+      </Row>
+      <Row>
+        <Label>즉시구매가</Label>
+        <Value>50,000 원</Value>
+      </Row>
+      <BuyNowButton>즉시 구매</BuyNowButton>
+    </InfoContainer>
+  )
+}

--- a/src/components/DetailPageComponents/ImageModule.tsx
+++ b/src/components/DetailPageComponents/ImageModule.tsx
@@ -1,0 +1,41 @@
+import React from 'react'
+import styled from 'styled-components';
+
+const MainImage = styled.img`
+  width: 850px;
+  height: 500px;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+`;
+
+const SubImageContainer = styled.div`
+  display: flex;
+  justify-content: space-between;
+  margin-top: 10px;
+  gap: 10px;
+`;
+
+const SubImage = styled.img`
+  width: 200px;
+  height: 120px;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+`;
+
+export default function ImageModule() {
+
+  return (
+    <>
+      <MainImage src='https://upload.wikimedia.org/wikipedia/commons/thumb/a/a7/React-icon.svg/1280px-React-icon.svg.png' />
+      <SubImageContainer>
+        <SubImage src='https://upload.wikimedia.org/wikipedia/commons/thumb/a/a7/React-icon.svg/1280px-React-icon.svg.png' />
+        <SubImage src='https://upload.wikimedia.org/wikipedia/commons/thumb/a/a7/React-icon.svg/1280px-React-icon.svg.png' />
+        <SubImage src='https://upload.wikimedia.org/wikipedia/commons/thumb/a/a7/React-icon.svg/1280px-React-icon.svg.png' />
+        <SubImage src='https://upload.wikimedia.org/wikipedia/commons/thumb/a/a7/React-icon.svg/1280px-React-icon.svg.png' />
+      </SubImageContainer>
+    </>
+
+  )
+}

--- a/src/components/DetailPageComponents/ImageModule.tsx
+++ b/src/components/DetailPageComponents/ImageModule.tsx
@@ -26,14 +26,17 @@ const SubImage = styled.img`
 
 export default function ImageModule() {
 
+  // 테스트용 더미 이미지
+  const imageSrc = 'https://upload.wikimedia.org/wikipedia/commons/thumb/1/19/Definitions_of_TV_standards.jpg/220px-Definitions_of_TV_standards.jpg'
+
   return (
     <>
-      <MainImage src='https://upload.wikimedia.org/wikipedia/commons/thumb/a/a7/React-icon.svg/1280px-React-icon.svg.png' />
+      <MainImage src={imageSrc} />
       <SubImageContainer>
-        <SubImage src='https://upload.wikimedia.org/wikipedia/commons/thumb/a/a7/React-icon.svg/1280px-React-icon.svg.png' />
-        <SubImage src='https://upload.wikimedia.org/wikipedia/commons/thumb/a/a7/React-icon.svg/1280px-React-icon.svg.png' />
-        <SubImage src='https://upload.wikimedia.org/wikipedia/commons/thumb/a/a7/React-icon.svg/1280px-React-icon.svg.png' />
-        <SubImage src='https://upload.wikimedia.org/wikipedia/commons/thumb/a/a7/React-icon.svg/1280px-React-icon.svg.png' />
+        <SubImage src={imageSrc} />
+        <SubImage src={imageSrc} />
+        <SubImage src={imageSrc} />
+        <SubImage src={imageSrc} />
       </SubImageContainer>
     </>
 

--- a/src/components/DetailPageComponents/ItemDescription.tsx
+++ b/src/components/DetailPageComponents/ItemDescription.tsx
@@ -1,0 +1,19 @@
+import React from 'react'
+import styled from 'styled-components'
+
+const Divider = styled.hr`
+  border: 1px solid #eee;
+  width: 95%;
+  border-color: black;
+  border-style: solid;
+  border-width: 1px 0 0 0;
+`
+export default function ItemDescription() {
+  return (
+    <div>
+      <h3>상세 설명</h3>
+      <Divider />
+      <p>Lorem ipsum dolor sit, amet consectetur adipisicing elit. Laboriosam mollitia ipsum esse harum optio officia incidunt quod numquam, fuga non ut ullam voluptas! Eveniet id illo dicta a, deleniti aperiam?</p>
+    </div>
+  )
+}

--- a/src/components/DetailPageComponents/ItemDescription.tsx
+++ b/src/components/DetailPageComponents/ItemDescription.tsx
@@ -3,17 +3,36 @@ import styled from 'styled-components'
 
 const Divider = styled.hr`
   border: 1px solid #eee;
-  width: 95%;
+  width: 98%;
   border-color: black;
   border-style: solid;
   border-width: 1px 0 0 0;
 `
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: baseline;
+`
+
+const Description = styled.p`
+  margin: 30px;
+  text-align: start;
+`
+
 export default function ItemDescription() {
   return (
-    <div>
-      <h3>상세 설명</h3>
+    <Wrapper>
       <Divider />
-      <p>Lorem ipsum dolor sit, amet consectetur adipisicing elit. Laboriosam mollitia ipsum esse harum optio officia incidunt quod numquam, fuga non ut ullam voluptas! Eveniet id illo dicta a, deleniti aperiam?</p>
-    </div>
+      <h3>Description</h3>
+      <Description>
+        Lorem ipsum dolor sit amet consectetur adipisicing elit. Amet ipsa iure assumenda quos sunt, obcaecati asperiores dignissimos dolor, soluta hic rerum? Distinctio tenetur fugiat possimus ex nulla, aliquam tempora at!
+        Lorem ipsum dolor sit, amet consectetur adipisicing elit. Laboriosam mollitia ipsum esse harum optio officia incidunt quod numquam, fuga non ut ullam voluptas! Eveniet id illo dicta a, deleniti aperiam?
+        Lorem ipsum dolor sit amet consectetur adipisicing elit. Quibusdam nihil consectetur accusantium iure tempora necessitatibus quaerat quos. Distinctio nam minima, ullam iste deleniti, laborum sapiente blanditiis quas autem atque at?
+        Lorem ipsum dolor sit amet consectetur adipisicing elit. Molestias, beatae officiis temporibus, dicta repudiandae facilis provident qui, nemo quisquam deleniti saepe vero sint fuga quaerat illum fugiat? Culpa, eveniet aperiam.
+        Lorem ipsum dolor sit amet consectetur adipisicing elit. Alias vel minus, repellat tenetur expedita, aliquid quo deserunt in doloremque voluptates dolorum corporis consequatur optio beatae aperiam! Ad pariatur facere in.
+        Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quidem perspiciatis, deleniti fugit beatae dicta eum velit eveniet architecto consequatur nostrum harum sit, sunt exercitationem, rerum quaerat doloribus possimus necessitatibus! Perspiciatis.
+        Lorem ipsum dolor sit amet consectetur adipisicing elit. Beatae iure quos quas minima odio ratione accusantium fugit ad velit sed, commodi harum aperiam voluptatibus mollitia minus? Distinctio temporibus fuga magni.
+      </Description>
+    </Wrapper>
   )
 }

--- a/src/components/DetailPageComponents/SameKeywordAuctions.tsx
+++ b/src/components/DetailPageComponents/SameKeywordAuctions.tsx
@@ -8,19 +8,42 @@ const Container = styled.div`
   border-radius: 10px;
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 24px;
+`
+
+const Row = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
 `
 
 export default function SameKeywordAuctions() {
   return (
     <Container>
-      <p>Lorem ipsum dolor sit, amet consectetur adipisicing elit. eius architecto?</p>
-      <p>Lorem ipsum dolor sit, amet consectetur adipisicing elit. eius architecto?</p>
-      <p>Lorem ipsum dolor sit, amet consectetur adipisicing elit. eius architecto?</p>
-      <p>Lorem ipsum dolor sit, amet consectetur adipisicing elit. eius architecto?</p>
-      <p>Lorem ipsum dolor sit, amet consectetur adipisicing elit. eius architecto?</p>
-      <p>Lorem ipsum dolor sit, amet consectetur adipisicing elit. eius architecto?</p>
-      <p>Lorem ipsum dolor sit, amet consectetur adipisicing elit. eius architecto?</p>
+      <Row>
+        <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit.</p>
+        <p>328,000 원</p>
+      </Row>
+      <Row>
+        <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit.</p>
+        <p>328,000 원</p>
+      </Row>
+      <Row>
+        <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit.</p>
+        <p>328,000 원</p>
+      </Row>
+      <Row>
+        <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit.</p>
+        <p>328,000 원</p>
+      </Row>
+      <Row>
+        <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit.</p>
+        <p>328,000 원</p>
+      </Row>
+      <Row>
+        <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit.</p>
+        <p>328,000 원</p>
+      </Row>
     </Container>
   )
 }

--- a/src/components/DetailPageComponents/SameKeywordAuctions.tsx
+++ b/src/components/DetailPageComponents/SameKeywordAuctions.tsx
@@ -1,0 +1,26 @@
+import React from 'react'
+import styled from 'styled-components';
+
+const Container = styled.div`
+  margin: 10px 0 0 0;
+  padding: 10px 16px;
+  background-color: lightblue;
+  border-radius: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+`
+
+export default function SameKeywordAuctions() {
+  return (
+    <Container>
+      <p>Lorem ipsum dolor sit, amet consectetur adipisicing elit. eius architecto?</p>
+      <p>Lorem ipsum dolor sit, amet consectetur adipisicing elit. eius architecto?</p>
+      <p>Lorem ipsum dolor sit, amet consectetur adipisicing elit. eius architecto?</p>
+      <p>Lorem ipsum dolor sit, amet consectetur adipisicing elit. eius architecto?</p>
+      <p>Lorem ipsum dolor sit, amet consectetur adipisicing elit. eius architecto?</p>
+      <p>Lorem ipsum dolor sit, amet consectetur adipisicing elit. eius architecto?</p>
+      <p>Lorem ipsum dolor sit, amet consectetur adipisicing elit. eius architecto?</p>
+    </Container>
+  )
+}

--- a/src/components/DetailPageComponents/SellerRating.tsx
+++ b/src/components/DetailPageComponents/SellerRating.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+
+export default function SellerRating() {
+  return (
+    <div>
+      <label>판매자 평점:</label>
+      <div>⭐️⭐️⭐️⭐️⭐️</div>
+    </div>
+  )
+}

--- a/src/components/DetailPageComponents/SellerRating.tsx
+++ b/src/components/DetailPageComponents/SellerRating.tsx
@@ -1,10 +1,14 @@
 import React from 'react'
 
+/**
+ * 
+ * @Todo: 이모지로 처리한 부분 추후 아이콘으로 변경
+ */
 export default function SellerRating() {
   return (
     <div>
-      <label>판매자 평점:</label>
-      <div>⭐️⭐️⭐️⭐️⭐️</div>
+      <label>판매자 평점: </label>
+      <span>⭐️⭐️⭐️⭐️⭐️</span>
     </div>
   )
 }

--- a/src/components/DetailPageComponents/SteamedButton.tsx
+++ b/src/components/DetailPageComponents/SteamedButton.tsx
@@ -1,0 +1,5 @@
+import React from 'react'
+
+export default function SteamedButton() {
+  return <button>찜하기 ❤️</button>
+}

--- a/src/components/DetailPageComponents/SteamedButton.tsx
+++ b/src/components/DetailPageComponents/SteamedButton.tsx
@@ -1,5 +1,9 @@
 import React from 'react'
 
+/**
+ * 
+ * @Todo: 이모지로 처리한 부분 추후 아이콘으로 변경
+ */
 export default function SteamedButton() {
   return <button>찜하기 ❤️</button>
 }

--- a/src/components/DetailPageComponents/index.tsx
+++ b/src/components/DetailPageComponents/index.tsx
@@ -31,6 +31,14 @@ const LeftContainer = styled.div`
 const RightContainer = styled.div`
 `
 
+const Functions = styled.div`
+  padding: 10px;
+  display: flex;
+  flex-direction: column;
+  align-items: baseline;
+  gap: 16px;
+`
+
 export default function DetailPageComponents() {
   return (
     <Container>
@@ -43,8 +51,10 @@ export default function DetailPageComponents() {
           <SameKeywordAuctions />
         </RightContainer>
       </AuctionContainer>
-      <SellerRating />
-      <SteamedButton />
+      <Functions>
+        <SellerRating />
+        <SteamedButton />
+      </Functions>
       <ItemDescription />
     </Container >
   );

--- a/src/components/DetailPageComponents/index.tsx
+++ b/src/components/DetailPageComponents/index.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import styled from 'styled-components';
+import AuctionInfoModule from './AuctionInfoModule';
+import ImageModule from './ImageModule';
+import ItemDescription from './ItemDescription';
+import SameKeywordAuctions from './SameKeywordAuctions';
+import SellerRating from './SellerRating';
+import SteamedButton from './SteamedButton';
+
+const Container = styled.div`
+  margin: 30px auto;
+  text-align: center;
+  max-width: 2048px;
+  width: 80vw;
+`;
+
+const AuctionContainer = styled.div`
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 30px;
+  @media (max-width: 768px) {
+    grid-template-columns: 1fr;
+  }
+`;
+
+const LeftContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+const RightContainer = styled.div`
+`
+
+export default function DetailPageComponents() {
+  return (
+    <Container>
+      <AuctionContainer>
+        <LeftContainer>
+          <ImageModule />
+        </LeftContainer>
+        <RightContainer>
+          <AuctionInfoModule />
+          <SameKeywordAuctions />
+        </RightContainer>
+      </AuctionContainer>
+      <SellerRating />
+      <SteamedButton />
+      <ItemDescription />
+    </Container >
+  );
+}

--- a/src/page/DetailPage.tsx
+++ b/src/page/DetailPage.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+import DetailPageComponents from '../components/DetailPageComponents';
+
+
+export default function DetailPage() {
+  return <DetailPageComponents />
+}


### PR DESCRIPTION
디테일 페이지의 요소 배치를 완료했습니다.

가능한 최대한 컴포넌트를 잘게 쪼갰습니다.

디테일 페이지의 경우 직접적으로 전역 상태를 사용할 일이 없을 것으로 예상되서 핵심 로직은 해당 컴포넌트 폴더 내의 index.tsx 파일에서 구현한 후 각 자식 컴포넌트에 내려줄 예정입니다.

마크업만 진행한 내용으로 자세한 내용은 코드를 참조해 주세요.

> 라우트의 경우 테스트 후 코드를 삭제한 상태이므로 이후 연결 작업이 필요합니다.